### PR TITLE
make generated transforms always public

### DIFF
--- a/aper/aper_derive/src/lib.rs
+++ b/aper/aper_derive/src/lib.rs
@@ -108,7 +108,7 @@ fn generate_transform(enum_name: &Ident, fields: &[Field]) -> TokenStream {
 
     quote! {
         #[derive(aper::Transition, serde::Serialize, serde::Deserialize, Debug, Clone, PartialEq)]
-        enum #enum_name {
+        pub enum #enum_name {
             #variants
         }
     }


### PR DESCRIPTION
This makes the macro usable with public structs. #22 

Probably it would be better to make the generated transform public only when the struct is public? I don't know how to cleanly put a conditional `pub` into the metaprogramming. I will learn how to if you agree that that is how it should be.