### PR TITLE
Better List serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,6 +378,7 @@ dependencies = [
  "aper_derive",
  "chrono",
  "serde",
+ "serde_json",
  "uuid",
 ]
 

--- a/aper/Cargo.toml
+++ b/aper/Cargo.toml
@@ -16,3 +16,6 @@ chrono = { version = "0.4.19", features = ["serde"] }
 serde = { version = "1.0.123", features = ["derive"] }
 uuid = { version = "0.8.2", features = ["serde", "v4", "wasm-bindgen"] }
 aper_derive = {path="./aper_derive"}
+
+[dev-dependencies]
+serde_json = "1.0.59"


### PR DESCRIPTION
Serialize List as (ZenoIndex, Uuid, T)-tuple instead of serializing each
map. This reduces its size and gets rid of the problem that Lists
couldn't be serialized into JSON.